### PR TITLE
Feature/interval ratio 3digit precision

### DIFF
--- a/lasercut/join.py
+++ b/lasercut/join.py
@@ -37,8 +37,8 @@ def get_slot_positions(tab_properties):
     if tab_properties.tabs_number % 2 == 1:
         slots_list.append(0.0 + tab_properties.tabs_shift)
         for i in range(half_tab_number):
-            left = float(i+1) * interval_length * tab_properties.interval_ratio
-            right = float(-i-1) * interval_length * tab_properties.interval_ratio
+            left = float(i+1) * interval_length
+            right = float(-i-1) * interval_length
             if tab_properties.interval_ratio != 1.0:
                 left *= tab_properties.interval_ratio
                 right *= tab_properties.interval_ratio

--- a/panel/tab.py
+++ b/panel/tab.py
@@ -48,7 +48,7 @@ class BaseTabWidget(ParamWidget):
                                 WidgetValue(type=float, name="tabs_shift", show_name="Shift", widget=None,
                                             interval_value=[-300, 300.], step=1., decimals=2),
                                 WidgetValue(type=float, name="interval_ratio", show_name="Interval ratio",
-                                            widget=None, interval_value=[0.1, 5.], step=0.1, decimals=2),
+                                            widget=None, interval_value=[0.1, 5.], step=0.1, decimals=3),
                                 WidgetValue(type=bool, name="dog_bone", show_name="Dog bone hole", widget=None),
                                 WidgetValue(type=bool, name="tab_dog_bone", show_name="Tab dog bone hole", widget=None)
                                  ])


### PR DESCRIPTION
HI! 
Awesome add-on... using it a lot lately. ... here is a thing about I like to improve the interval settings. 
Maybe you can kindly hint me to any test procedure to validate the PR~,

Itentions: 
- 1st change I interpret there is a bug in the interval_ration option as - for odd number of tabs - is multiplied twice (also line [43,44](https://github.com/execuc/LCInterlocking/pull/56/commits/70336ae171892ea60102c884094f21e7db6c3012#diff-5bb1688e17461f9175db29be04a788e6bcd4df970f0040f3a436784b64e41e54L43))
- 2nd change: For me i had a total length of 18cm and wanted to have 7-8 tabs on it. limiting the ratio to 2 decimals did not allow me to get results in a accuracy of 0.2mm (1% of 18cm) which adds up to around 2mm after the 10th tab.